### PR TITLE
Update to 1028 (CLI hooks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To read more on when and how to submit an RFC document, see RFC 1.
 * [RFC 1021 - Mutation rewrites](./text/1021-rewrites.rst) (accepted)
 * [RFC 1023 - Adding Splats Syntax](./text/1023-splats.rst) (accepted)
 * [RFC 1025 - Database Branches](./text/1025-branches.rst) (accepted)
+* [RFC 1028 - CLI hooks](./text/1028-cli-hooks.rst) (accepted)
 
 ## License
 

--- a/text/1028-cli-hooks.rst
+++ b/text/1028-cli-hooks.rst
@@ -64,8 +64,8 @@ indicate which commands will trigger the hooks. The exception to that is the
 of schema change, regardless of which command causes it.
 
 All hooks will use the project root directory as the execution directory.
-Hooks are executed using ``/bin/sh`` on all platforms. On Windows, the hooks
-are always executed in WSL.
+Hooks are executed using ``/bin/sh`` on Unix-like platforms and ``cmd.exe``
+on Windows.
 
 If the shell exits with a non-zero status code, the CLI will exit immediately,
 without executing any subsequent hooks or CLI actions.
@@ -248,8 +248,8 @@ The values corresponding to the keys are strings that are going to be executed
 as shell commands, much like for the hooks.
 
 All watch scripts will use the project root directory as the execution
-directory. They are executed using ``/bin/sh`` on all platforms. On Windows,
-the scripts are always executed in WSL.
+directory. They are executed using ``/bin/sh`` on Unix-like platforms and 
+using ``cmd.exe`` on Windows.
 
 An example of this configuration::
 


### PR DESCRIPTION
Executing hooks and scripts on Windows in WSL comes with significant downsides:
- WSL needs to be installed (which is otherwise not required if you don't use local portable instances),
- WSL contains a different user environment than the outside Window filesystem (credentials.json, project stash, ...). We could copy this env into WLS or hint the CLI in WLS to use the env from Windows paths. But this gets really complicated and fragile real quick.

Instead, I propose we do the same thing as npm-run-script: use cmd.exe instead.

If portable scripts beyond a simple program invocation are needed, users can still use Python or anything else that is portable. 